### PR TITLE
Make S3 module blocking when state is not changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ gui from [http://localhost:8000](http://localhost:8000).
 Start the `runS3.sh` program which contains some example environment variables.
 If tamer works you should see messages appearing in the kafka gui.
 
+#### Known Issues
+
+The file list from the bucket is not synchronized with the main thread. This means that
+oftentimes, when tamer resumes, you have to wait the minimum time interval between S3 fetches
+before seeing some activity. This happens because the main thread may start processing before
+the file list is downloaded. This should not impinge on functionality.
+
 ## License
 
 Tamer is licensed under the **[MIT License](LICENSE)** (the "License"); you may not use this software except in

--- a/s3/src/main/scala/tamer/s3/Setup.scala
+++ b/s3/src/main/scala/tamer/s3/Setup.scala
@@ -9,13 +9,13 @@ import java.time.Duration
 import scala.util.hashing.MurmurHash3.stringHash
 
 final case class Setup[R, V <: Product: Encoder: Decoder: SchemaFor](
-  bucketName: String,
-  prefix: String,
-  afterwards: LastProcessedInstant,
-  transducer: ZTransducer[R, TamerError, Byte, V],
-  parallelism: PosInt,
-  zonedDateTimeFormatter: ZonedDateTimeFormatter,
-  minimumIntervalForBucketFetch: Duration
+    bucketName: String,
+    prefix: String,
+    afterwards: LastProcessedInstant,
+    transducer: ZTransducer[R, TamerError, Byte, V],
+    parallelism: PosInt,
+    zonedDateTimeFormatter: ZonedDateTimeFormatter,
+    minimumIntervalForBucketFetch: Duration
 ) extends _root_.tamer.Setup[S3Object, V, LastProcessedInstant](
       Serde[S3Object](isKey = true).serializer,
       Serde[V]().serializer,
@@ -25,13 +25,13 @@ final case class Setup[R, V <: Product: Encoder: Decoder: SchemaFor](
     )
 object Setup {
   final def fromZonedDateTimeFormatter[R, V <: Product: Encoder: Decoder: SchemaFor](
-    bucketName: String,
-    filePathPrefix: String,
-    afterwards: LastProcessedInstant,
-    transducer: ZTransducer[R, TamerError, Byte, V],
-    parallelism: PosInt,
-    zonedDateTimeFormatter: ZonedDateTimeFormatter,
-    minimumIntervalForBucketFetch: Duration
+      bucketName: String,
+      filePathPrefix: String,
+      afterwards: LastProcessedInstant,
+      transducer: ZTransducer[R, TamerError, Byte, V],
+      parallelism: PosInt,
+      zonedDateTimeFormatter: ZonedDateTimeFormatter,
+      minimumIntervalForBucketFetch: Duration
   ): Setup[R, V] = Setup[R, V](
     bucketName,
     filePathPrefix,

--- a/s3/src/main/scala/tamer/s3/Setup.scala
+++ b/s3/src/main/scala/tamer/s3/Setup.scala
@@ -3,19 +3,19 @@ package s3
 
 import com.sksamuel.avro4s.{Decoder, Encoder, SchemaFor}
 import eu.timepit.refined.types.numeric.PosInt
-import zio.stream.Transducer
+import zio.stream.ZTransducer
 
 import java.time.Duration
 import scala.util.hashing.MurmurHash3.stringHash
 
-final case class Setup[V <: Product: Encoder: Decoder: SchemaFor](
-    bucketName: String,
-    prefix: String,
-    afterwards: LastProcessedInstant,
-    transducer: Transducer[TamerError, Byte, V],
-    parallelism: PosInt,
-    zonedDateTimeFormatter: ZonedDateTimeFormatter,
-    minimumIntervalForBucketFetch: Duration
+final case class Setup[R, V <: Product: Encoder: Decoder: SchemaFor](
+  bucketName: String,
+  prefix: String,
+  afterwards: LastProcessedInstant,
+  transducer: ZTransducer[R, TamerError, Byte, V],
+  parallelism: PosInt,
+  zonedDateTimeFormatter: ZonedDateTimeFormatter,
+  minimumIntervalForBucketFetch: Duration
 ) extends _root_.tamer.Setup[S3Object, V, LastProcessedInstant](
       Serde[S3Object](isKey = true).serializer,
       Serde[V]().serializer,
@@ -24,13 +24,21 @@ final case class Setup[V <: Product: Encoder: Decoder: SchemaFor](
       stringHash(bucketName) + stringHash(prefix) + afterwards.instant.getEpochSecond.intValue
     )
 object Setup {
-  final def fromZonedDateTimeFormatter[V <: Product: Encoder: Decoder: SchemaFor](
-      bucketName: String,
-      filePathPrefix: String,
-      afterwards: LastProcessedInstant,
-      transducer: Transducer[TamerError, Byte, V],
-      parallelism: PosInt,
-      zonedDateTimeFormatter: ZonedDateTimeFormatter,
-      minimumIntervalForBucketFetch: Duration
-  ): Setup[V] = Setup[V](bucketName, filePathPrefix, afterwards, transducer, parallelism, zonedDateTimeFormatter, minimumIntervalForBucketFetch)
+  final def fromZonedDateTimeFormatter[R, V <: Product: Encoder: Decoder: SchemaFor](
+    bucketName: String,
+    filePathPrefix: String,
+    afterwards: LastProcessedInstant,
+    transducer: ZTransducer[R, TamerError, Byte, V],
+    parallelism: PosInt,
+    zonedDateTimeFormatter: ZonedDateTimeFormatter,
+    minimumIntervalForBucketFetch: Duration
+  ): Setup[R, V] = Setup[R, V](
+    bucketName,
+    filePathPrefix,
+    afterwards,
+    transducer,
+    parallelism,
+    zonedDateTimeFormatter,
+    minimumIntervalForBucketFetch
+  )
 }


### PR DESCRIPTION
S3 runs indefinitely with the same query and the same result when there are no new files to process. In addition to create useless data, this is also dangerous in case of replays because it appears the same file must be read over and over.

The solution is to strictly monotonically advance state by creating a new thread that blocks until new files are available.