### PR TITLE
Feature/timeout on simplified rest api

### DIFF
--- a/rest/src/main/scala/tamer/rest/TamerRestJob.scala
+++ b/rest/src/main/scala/tamer/rest/TamerRestJob.scala
@@ -16,7 +16,6 @@ import zio.duration.{durationInt, Duration => ZDuration}
 import zio.{Chunk, Has, Queue, RIO, Ref, Schedule, Task, UIO, ULayer, URIO, ZEnv, ZIO, ZLayer, clock}
 
 import java.time.Instant
-import java.util.concurrent.TimeUnit
 import scala.annotation.{nowarn, unused}
 import scala.concurrent.duration.Duration
 import scala.util.hashing.MurmurHash3.stringHash

--- a/rest/src/main/scala/tamer/rest/TamerRestJob.scala
+++ b/rest/src/main/scala/tamer/rest/TamerRestJob.scala
@@ -93,7 +93,8 @@ object TamerRestJob {
       offsetParameterName: String = "page",
       increment: Int = 1,
       fixedPageElementCount: Option[Int] = None,
-      authenticationMethod: Option[Authentication[R]] = None
+      authenticationMethod: Option[Authentication[R]] = None,
+      readRequestTimeout: zio.duration.Duration = 30.seconds
   )(deriveKafkaRecordKey: (Offset, V) => K): TamerRestJob[R, K, V, Offset] = {
     val queryBuilder: RestQueryBuilder[R, Offset] = new RestQueryBuilder[R, Offset] {
 
@@ -102,7 +103,7 @@ object TamerRestJob {
       override val queryId: Int = stringHash(baseUrl + offsetParameterName) + increment
 
       override def query(state: Offset): Request[Either[String, String], Any] =
-        basicRequest.get(uri"$baseUrl".addParam(offsetParameterName, state.offset.toString)).readTimeout(Duration(20, TimeUnit.SECONDS))
+        basicRequest.get(uri"$baseUrl".addParam(offsetParameterName, state.offset.toString)).readTimeout(Duration.fromNanos(readRequestTimeout.toNanos))
 
       override val authentication: Option[Authentication[R]] = authenticationMethod
     }
@@ -174,7 +175,8 @@ object TamerRestJob {
       increment: Int = 1,
       authenticationMethod: Option[Authentication[R]] = None,
       minPeriod: zio.duration.Duration = 5.minutes,
-      maxPeriod: zio.duration.Duration = 1.hour
+      maxPeriod: zio.duration.Duration = 1.hour,
+      readRequestTimeout: zio.duration.Duration = 30.seconds
   )(deriveKafkaRecordKey: (PeriodicOffset, V) => K): TamerRestJob[R, K, V, PeriodicOffset] = {
     val queryBuilder: RestQueryBuilder[R with Clock, PeriodicOffset] = new RestQueryBuilder[R, PeriodicOffset] {
 
@@ -183,7 +185,7 @@ object TamerRestJob {
       override val queryId: Int = stringHash(baseUrl + offsetParameterName) + increment
 
       override def query(state: PeriodicOffset): Request[Either[String, String], Any] =
-        basicRequest.get(uri"$baseUrl".addParam(offsetParameterName, state.offset.toString)).readTimeout(Duration(20, TimeUnit.SECONDS))
+        basicRequest.get(uri"$baseUrl".addParam(offsetParameterName, state.offset.toString)).readTimeout(Duration.fromNanos(readRequestTimeout.toNanos))
 
       override val authentication: Option[Authentication[R]] = authenticationMethod
     }

--- a/rest/src/main/scala/tamer/rest/TamerRestJob.scala
+++ b/rest/src/main/scala/tamer/rest/TamerRestJob.scala
@@ -102,7 +102,9 @@ object TamerRestJob {
       override val queryId: Int = stringHash(baseUrl + offsetParameterName) + increment
 
       override def query(state: Offset): Request[Either[String, String], Any] =
-        basicRequest.get(uri"$baseUrl".addParam(offsetParameterName, state.offset.toString)).readTimeout(Duration.fromNanos(readRequestTimeout.toNanos))
+        basicRequest
+          .get(uri"$baseUrl".addParam(offsetParameterName, state.offset.toString))
+          .readTimeout(Duration.fromNanos(readRequestTimeout.toNanos))
 
       override val authentication: Option[Authentication[R]] = authenticationMethod
     }
@@ -184,7 +186,9 @@ object TamerRestJob {
       override val queryId: Int = stringHash(baseUrl + offsetParameterName) + increment
 
       override def query(state: PeriodicOffset): Request[Either[String, String], Any] =
-        basicRequest.get(uri"$baseUrl".addParam(offsetParameterName, state.offset.toString)).readTimeout(Duration.fromNanos(readRequestTimeout.toNanos))
+        basicRequest
+          .get(uri"$baseUrl".addParam(offsetParameterName, state.offset.toString))
+          .readTimeout(Duration.fromNanos(readRequestTimeout.toNanos))
 
       override val authentication: Option[Authentication[R]] = authenticationMethod
     }


### PR DESCRIPTION
https://github.com/laserdisc-io/tamer/issues/328#issue-884269440
> While connection timeout in STTP is a global setting, and thus easily configurable, read timeout is per request, this means there is no way to set it using the simplified API (because the query builder is provided).
It would be cool to add it as an additional optional setting.

Moreover this change is backwards compatible