### PR TITLE
[oci-objectstorage] Add objectNameFinder predicate

### DIFF
--- a/example/src/main/scala/tamer/example/OciObjectStorageSimple.scala
+++ b/example/src/main/scala/tamer/example/OciObjectStorageSimple.scala
@@ -43,6 +43,7 @@ object OciObjectStorageSimple extends zio.App {
       "namespace",
       "bucketName",
       None,
+      _ => true,
       objectNameBuilder,
       OciObjectStorageConfiguration.State(initialState, getNextState, (o: ObjectsCursor, _: MyLine) => o),
       transducer

--- a/oci-objectstorage/src/main/scala/tamer/oci/objectstorage/OciObjectStorageConfiguration.scala
+++ b/oci-objectstorage/src/main/scala/tamer/oci/objectstorage/OciObjectStorageConfiguration.scala
@@ -29,6 +29,7 @@ final case class OciObjectStorageConfiguration[
     namespace: String,
     bucketName: String,
     prefix: Option[String],
+    objectNameFinder: String => Boolean,
     objectNameBuilder: ObjectNameBuilder[S],
     transitions: OciObjectStorageConfiguration.State[R, K, V, S],
     transducer: ZTransducer[R, TamerError, Byte, V]


### PR DESCRIPTION
Currently the logic used to get the name of the next object from Object Storage heavily relies on `prefix`. It works fine in scenarios that object names are prefixed by their distinguishing property but fails in other settings.

This PR adds a predicate that's used to `find` the first object that matches the desired property.