### PR TITLE
Make registry client use global properties

### DIFF
--- a/core/src/main/scala/tamer/Tamer.scala
+++ b/core/src/main/scala/tamer/Tamer.scala
@@ -214,7 +214,9 @@ object Tamer {
         _     <- runLoop(queue, log)
       } yield ()
 
-      logic.refineOrDie(tamerErrors).provideSomeLayer[Clock](config.schemaRegistryUrl.map(Registry.live(_)).getOrElse(Registry.fake))
+      logic
+        .refineOrDie(tamerErrors)
+        .provideSomeLayer[Clock](config.schemaRegistryUrl.map(Registry.live(_, configuration = config.properties)).getOrElse(Registry.fake))
     }
   }
 


### PR DESCRIPTION
This will make the schema registry client share the properties of the global kafka configuration. Ideally there should be a way to put custom values for that but this should cover 99% of use cases.