### PR TITLE
remove TamerError from signatures, run and runWith lift errors into f…

### DIFF
--- a/core/src/main/scala/tamer/Registry.scala
+++ b/core/src/main/scala/tamer/Registry.scala
@@ -92,10 +92,10 @@ object Registry {
     override final def verifySchema(id: Int, schema: Schema): Task[Unit]           = ZIO.unit
   }
 
-  private[tamer] final val fakeRegistryZIO: ZIO[Scope, TamerError, Registry] = ZIO.succeed(Registry.FakeRegistry)
+  private[tamer] final val fakeRegistryZIO: RIO[Scope, Registry] = ZIO.succeed(Registry.FakeRegistry)
 }
 
-final case class RegistryProvider(from: RegistryConfig => ZIO[Scope, TamerError, Registry])
+final case class RegistryProvider(from: RegistryConfig => RIO[Scope, Registry])
 
 object RegistryProvider {
   implicit final val defaultRegistryProvider: RegistryProvider = RegistryProvider { config =>

--- a/core/src/main/scala/tamer/Serdes.scala
+++ b/core/src/main/scala/tamer/Serdes.scala
@@ -32,7 +32,7 @@ sealed trait Serdes[K, V, SV] {
     "  - \u001b[36mtamer.RegistryProvider\u001b[0m\n"
 )
 sealed trait SerdesProvider[K, V, SV] {
-  def using(maybeRegistryConfig: Option[RegistryConfig]): ZIO[Scope, TamerError, Serdes[K, V, SV]]
+  def using(maybeRegistryConfig: Option[RegistryConfig]): RIO[Scope, Serdes[K, V, SV]]
 }
 
 object SerdesProvider {
@@ -40,7 +40,7 @@ object SerdesProvider {
       implicit SK: Codec[Tamer.StateKey],
       registryProvider: RegistryProvider
   ): SerdesProvider[K, V, SV] = new SerdesProvider[K, V, SV] {
-    override final def using(maybeRegistryConfig: Option[RegistryConfig]): ZIO[Scope, TamerError, Serdes[K, V, SV]] =
+    override final def using(maybeRegistryConfig: Option[RegistryConfig]): RIO[Scope, Serdes[K, V, SV]] =
       maybeRegistryConfig.fold(Registry.fakeRegistryZIO)(registryProvider.from(_)).map { registry =>
         new Serdes[K, V, SV] {
           override final val keySerializer: Serializer[Any, K]          = Serde.key[K].using(registry)

--- a/core/src/main/scala/tamer/Setup.scala
+++ b/core/src/main/scala/tamer/Setup.scala
@@ -9,7 +9,6 @@ abstract class Setup[-R, K: Tag, V: Tag, SV: Tag](implicit val serdesProvider: S
   val repr: String = "no repr string implemented, if you want a neat description of the source configuration please implement it"
   def iteration(currentState: SV, queue: Enqueue[NonEmptyChunk[(K, V)]]): RIO[R, SV]
 
-  final val run: ZIO[R with KafkaConfig, TamerError, Unit] = runLoop.provideSomeLayer(Tamer.live(this))
-  final def runWith[E >: TamerError, R1](layer: Layer[E, R with KafkaConfig with R1]): IO[E, Unit] =
-    runLoop.provideLayer(layer >>> Tamer.live(this))
+  final val run: RIO[R with KafkaConfig, Unit]                                    = runLoop.provideSomeLayer(Tamer.live(this)).orDie
+  final def runWith[R1](layer: TaskLayer[R with KafkaConfig with R1]): Task[Unit] = runLoop.provideLayer(layer >>> Tamer.live(this)).orDie
 }

--- a/core/src/main/scala/tamer/config.scala
+++ b/core/src/main/scala/tamer/config.scala
@@ -69,7 +69,7 @@ object KafkaConfig {
     KafkaConfig(brokers, maybeRegistry, closeTimeout, bufferSize, sink, state, transactionalId)
   }.nested("kafka")
 
-  final val fromEnvironment: Layer[TamerError, KafkaConfig] = ZLayer {
+  final val fromEnvironment: TaskLayer[KafkaConfig] = ZLayer {
     ZIO.config(kafkaConfigValue).mapError(ce => TamerError(ce.getMessage(), ce))
   }
 }

--- a/core/src/main/scala/tamer/package.scala
+++ b/core/src/main/scala/tamer/package.scala
@@ -1,7 +1,7 @@
-import zio.ZIO
+import zio.{RIO, ZIO}
 
 package object tamer {
-  final val runLoop: ZIO[Tamer, TamerError, Unit] = ZIO.serviceWithZIO(_.runLoop)
+  final val runLoop: RIO[Tamer, Unit] = ZIO.serviceWithZIO(_.runLoop)
 
   implicit final class HashableOps[A](private val _underlying: A) extends AnyVal {
     def hash(implicit A: Hashable[A]): Int = A.hash(_underlying)

--- a/core/src/test/scala/tamer/TamerSpec.scala
+++ b/core/src/test/scala/tamer/TamerSpec.scala
@@ -19,7 +19,7 @@ object TamerSpec extends ZIOSpecDefault with TamerSpecGen {
       override final val initialState = State(0)
       override final val stateKey     = 0
       override final val recordKey    = (s: State, _: Value) => Key(s.state + 1)
-      override final def iteration(s: State, q: Enqueue[NonEmptyChunk[(Key, Value)]]): ZIO[Ref[Log], TamerError, State] =
+      override final def iteration(s: State, q: Enqueue[NonEmptyChunk[(Key, Value)]]): RIO[Ref[Log], State] =
         ZIO.service[Ref[Log]].flatMap { variable =>
           val cursor = s.state + 1
           if (cursor <= 10)

--- a/db/src/main/scala/tamer/db/config.scala
+++ b/db/src/main/scala/tamer/db/config.scala
@@ -16,7 +16,7 @@ object DbConfig {
       DbConfig(driver, uri, username, password, fetchChunkSize)
     }
 
-  final val fromEnvironment: Layer[TamerError, DbConfig] = ZLayer {
+  final val fromEnvironment: TaskLayer[DbConfig] = ZLayer {
     ZIO.config(dbConfigValue).mapError(ce => TamerError(ce.getMessage(), ce))
   }
 }

--- a/example/src/main/scala/tamer/db/DatabaseGeneralized.scala
+++ b/example/src/main/scala/tamer/db/DatabaseGeneralized.scala
@@ -20,6 +20,6 @@ object DatabaseGeneralized extends ZIOAppDefault {
             val mostRecent = results.sortBy(_.modifiedAt).max.timestamp
             Clock.instant.map(now => MyState(mostRecent, (mostRecent + 5.minutes).or(now)))
         }
-      ).runWith(dbLayerFromEnvironment ++ KafkaConfig.fromEnvironment).exitCode
+      ).runWith(dbLayerFromEnvironment ++ KafkaConfig.fromEnvironment)
     }
 }

--- a/example/src/main/scala/tamer/db/DatabaseSimple.scala
+++ b/example/src/main/scala/tamer/db/DatabaseSimple.scala
@@ -15,5 +15,4 @@ object DatabaseSimple extends ZIOAppDefault {
       sql"""SELECT id, name, description, modified_at FROM users WHERE modified_at > ${window.from} AND modified_at <= ${window.to}""".query[Row]
     )(recordKey = (_, v) => v.id, from = Instant.parse("2020-01-01T00:00:00.00Z"), tumblingStep = 5.days)
     .runWith(dbLayerFromEnvironment ++ KafkaConfig.fromEnvironment)
-    .exitCode
 }

--- a/example/src/main/scala/tamer/oci/objectstorage/OciObjectStorageSimple.scala
+++ b/example/src/main/scala/tamer/oci/objectstorage/OciObjectStorageSimple.scala
@@ -22,5 +22,5 @@ object OciObjectStorageSimple extends ZIOAppDefault {
     },
     objectName = _.current,
     startAfter = _.startAfter
-  ).runWith(objectStorageLayer(US_PHOENIX_1, ObjectStorageAuth.fromConfigFileDefaultProfile) ++ KafkaConfig.fromEnvironment).exitCode
+  ).runWith(objectStorageLayer(US_PHOENIX_1, ObjectStorageAuth.fromConfigFileDefaultProfile) ++ KafkaConfig.fromEnvironment)
 }

--- a/example/src/main/scala/tamer/rest/RESTBasicAuth.scala
+++ b/example/src/main/scala/tamer/rest/RESTBasicAuth.scala
@@ -31,5 +31,4 @@ object RESTBasicAuth extends ZIOAppDefault {
       increment = 2
     )
     .runWith(restLive() ++ KafkaConfig.fromEnvironment)
-    .exitCode
 }

--- a/example/src/main/scala/tamer/rest/RESTCustomAuth.scala
+++ b/example/src/main/scala/tamer/rest/RESTCustomAuth.scala
@@ -18,7 +18,7 @@ object RESTCustomAuth extends ZIOAppDefault {
 
   val authentication: Authentication[SttpClient] = new Authentication[SttpClient] {
     override def addAuthentication(request: SttpRequest, bearerToken: Option[String]): SttpRequest = request.auth.bearer(bearerToken.getOrElse(""))
-    override def setSecret(secretRef: Ref[Option[String]]): ZIO[SttpClient, TamerError, Unit] = {
+    override def setSecret(secretRef: Ref[Option[String]]): RIO[SttpClient, Unit] = {
       val fetchToken = send(basicRequest.get(uri"http://localhost:9395/auth").auth.basic("user", "pass"))
         .flatMap(_.body match {
           case Left(error)  => ZIO.fail(TamerError(error))
@@ -43,5 +43,4 @@ object RESTCustomAuth extends ZIOAppDefault {
       increment = 2
     )
     .runWith(restLive() ++ KafkaConfig.fromEnvironment)
-    .exitCode
 }

--- a/example/src/main/scala/tamer/rest/RESTDynamicData.scala
+++ b/example/src/main/scala/tamer/rest/RESTDynamicData.scala
@@ -15,14 +15,13 @@ object RESTDynamicData extends ZIOAppDefault {
       ZIO.attempt(body.split(",").toList.filterNot(_.isBlank))
     }
 
-  def program(now: Instant) = RESTSetup
-    .periodicallyPaginated(
-      baseUrl = "http://localhost:9395/dynamic-pagination",
-      pageDecoder = pageDecoder,
-      periodStart = now
-    )((_, data) => data)
-    .runWith(restLive() ++ KafkaConfig.fromEnvironment)
-    .exitCode
-
-  override final val run = Clock.instant.flatMap(program(_))
+  override final val run = Clock.instant.flatMap { now =>
+    RESTSetup
+      .periodicallyPaginated(
+        baseUrl = "http://localhost:9395/dynamic-pagination",
+        pageDecoder = pageDecoder,
+        periodStart = now
+      )((_, data) => data)
+      .runWith(restLive() ++ KafkaConfig.fromEnvironment)
+  }
 }

--- a/example/src/main/scala/tamer/rest/RESTSimple.scala
+++ b/example/src/main/scala/tamer/rest/RESTSimple.scala
@@ -20,5 +20,4 @@ object RESTSimple extends ZIOAppDefault {
       fixedPageElementCount = Some(3)
     )
     .runWith(restLive() ++ KafkaConfig.fromEnvironment)
-    .exitCode
 }

--- a/example/src/main/scala/tamer/s3/S3Generalized.scala
+++ b/example/src/main/scala/tamer/s3/S3Generalized.scala
@@ -48,5 +48,5 @@ object S3Generalized extends ZIOAppDefault {
     recordKey = (l: Long, _: String) => l,
     selectObjectForState = (l: Long, _: Keys) => internals.selectObjectForInstant(l),
     stateFold = internals.getNextState
-  ).runWith(Scope.default >>> (liveZIO(AF_SOUTH_1, s3.providers.default, Some(new URI("http://localhost:9000"))) ++ myKafkaConfigLayer)).exitCode
+  ).runWith(Scope.default >>> (liveZIO(AF_SOUTH_1, s3.providers.default, Some(new URI("http://localhost:9000"))) ++ myKafkaConfigLayer))
 }

--- a/example/src/main/scala/tamer/s3/S3Simple.scala
+++ b/example/src/main/scala/tamer/s3/S3Simple.scala
@@ -19,5 +19,4 @@ object S3Simple extends ZIOAppDefault {
       dateTimeFormatter = ZonedDateTimeFormatter.fromPattern("yyyy-MM-dd HH:mm:ss", ZoneId.of("Europe/Rome"))
     )
     .runWith(Scope.default >>> (liveZIO(AF_SOUTH_1, s3.providers.default, Some(new URI("http://localhost:9000"))) ++ KafkaConfig.fromEnvironment))
-    .exitCode
 }

--- a/oci-objectstorage/src/main/scala/tamer/oci/objectstorage/package.scala
+++ b/oci-objectstorage/src/main/scala/tamer/oci/objectstorage/package.scala
@@ -2,11 +2,11 @@ package tamer
 package oci
 
 import com.oracle.bmc.Region
-import zio.{RIO, ZLayer}
+import zio.{RIO, RLayer, ZLayer}
 import zio.oci.objectstorage._
 
 package object objectstorage {
-  final def objectStorageLayer[R](region: Region, auth: RIO[R, ObjectStorageAuth]): ZLayer[R, TamerError, ObjectStorage] =
+  final def objectStorageLayer[R](region: Region, auth: RIO[R, ObjectStorageAuth]): RLayer[R, ObjectStorage] =
     ZLayer(auth).flatMap(auth => ObjectStorage.live(ObjectStorageSettings(region, auth.get))).mapError { e =>
       TamerError(e.getLocalizedMessage, e)
     }

--- a/rest/src/main/scala/tamer/rest/package.scala
+++ b/rest/src/main/scala/tamer/rest/package.scala
@@ -5,7 +5,7 @@ import sttp.capabilities.{Effect, WebSockets}
 import sttp.capabilities.zio.ZioStreams
 import sttp.client4.{BackendOptions, Request, Response}
 import sttp.client4.httpclient.zio._
-import zio.{Layer, Ref, Task}
+import zio.{Ref, Task, TaskLayer}
 
 package object rest {
   type EphemeralSecretCache = Ref[Option[String]]
@@ -16,7 +16,7 @@ package object rest {
       options: BackendOptions = BackendOptions.Default,
       customizeRequest: HttpRequest => HttpRequest = identity,
       customEncodingHandler: HttpClientZioBackend.ZioEncodingHandler = PartialFunction.empty
-  ): Layer[TamerError, SttpClient with EphemeralSecretCache] =
+  ): TaskLayer[SttpClient with EphemeralSecretCache] =
     HttpClientZioBackend
       .layer(options, customizeRequest, customEncodingHandler)
       .mapError(e => TamerError(e.getLocalizedMessage(), e)) ++ EphemeralSecretCache.live


### PR DESCRIPTION
…ailures, examples remove .exitCode which converts failures into exit code 1 and swallows traces