### PR TITLE
Propagate configuration properties to the AdminClientSettings, see #1392

### DIFF
--- a/core/src/main/scala/tamer/Tamer.scala
+++ b/core/src/main/scala/tamer/Tamer.scala
@@ -326,7 +326,7 @@ object Tamer {
 
       val KafkaConfig(brokers, _, closeTimeout, _, _, _, groupId, clientId, transactionalId, properties) = config
 
-      val adminClientSettings = AdminClientSettings(closeTimeout, Map.empty)
+      val adminClientSettings = AdminClientSettings(closeTimeout, properties)
         .withBootstrapServers(brokers)
       val consumerSettings = ConsumerSettings(brokers)
         .withClientId(clientId)


### PR DESCRIPTION
This should fix #1392 by propagating the driver propertis to the `AdminClientSettings` that weren't propagated in `0.20.2`